### PR TITLE
Enforce OpenAI Realtime tool preamble modes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Centralized version management for all projects -->
   <PropertyGroup>
-    <Version>10.2.0</Version>
+    <Version>10.2.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     

--- a/Provider/Ai.Tlbx.VoiceAssistant.Provider.OpenAi.AspNetCore/OpenAiDirectRealtimeSessionRegistry.cs
+++ b/Provider/Ai.Tlbx.VoiceAssistant.Provider.OpenAi.AspNetCore/OpenAiDirectRealtimeSessionRegistry.cs
@@ -236,8 +236,9 @@ internal sealed class OpenAiDirectRealtimeSessionRegistry : IOpenAiDirectRealtim
             ToolCallPreambleMode.ProviderDefault => null,
             ToolCallPreambleMode.Disabled =>
                 "# Tool call preambles" + Environment.NewLine +
-                "- Do not speak a preamble before tool calls." + Environment.NewLine +
-                "- Call tools directly when the user's intent is clear.",
+                "- Do not speak a preamble before, between, or during tool calls." + Environment.NewLine +
+                "- Call tools directly when the user's intent is clear and remain silent until the final answer or a required clarification." + Environment.NewLine +
+                "- Never repeat, paraphrase, or acknowledge the user's request as filler while tools are running.",
             ToolCallPreambleMode.BeforeToolBurst =>
                 "# Tool call preambles" + Environment.NewLine +
                 "- If a user request requires a burst of multiple tool calls, say one short bridge sentence before the burst." + Environment.NewLine +

--- a/Provider/Ai.Tlbx.VoiceAssistant.Provider.OpenAi/OpenAiVoiceProvider.cs
+++ b/Provider/Ai.Tlbx.VoiceAssistant.Provider.OpenAi/OpenAiVoiceProvider.cs
@@ -1015,13 +1015,16 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 OnUsageReceived?.Invoke(report);
             }
 
+            // Bei deaktivierten Zwischenansagen ist die Phase erst in response.done
+            // zuverlässig bekannt. Deshalb zuerst ausschließlich freigegebene Ausgabe
+            // zustellen; Telemetrie-Callbacks dürfen die Audioausgabe nicht verhindern.
+            FlushBufferedOutput(root);
+
             if (trace != null)
             {
                 PopulateResponseTrace(root, trace, report);
                 OnResponseTraceCompleted?.Invoke(trace);
             }
-
-            FlushBufferedOutput(root);
 
             _currentResponseTrace = null;
             _currentResponseOutputText.Clear();

--- a/Provider/Ai.Tlbx.VoiceAssistant.Provider.OpenAi/OpenAiVoiceProvider.cs
+++ b/Provider/Ai.Tlbx.VoiceAssistant.Provider.OpenAi/OpenAiVoiceProvider.cs
@@ -50,6 +50,9 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
         private readonly StringBuilder _currentResponseOutputText = new();
         private string? _currentResponseAudioTranscript;
         private string? _lastInputTranscript;
+        private readonly Dictionary<string, List<string>> _bufferedAudioByItemId = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, string> _bufferedTranscriptsByItemId = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, StringBuilder> _bufferedTextByItemId = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets a value indicating whether the provider is connected and ready.
@@ -521,8 +524,9 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 ToolCallPreambleMode.ProviderDefault => null,
                 ToolCallPreambleMode.Disabled =>
                     "# Tool call preambles" + Environment.NewLine +
-                    "- Do not speak a preamble before tool calls." + Environment.NewLine +
-                    "- Call tools directly when the user's intent is clear.",
+                    "- Do not speak a preamble before, between, or during tool calls." + Environment.NewLine +
+                    "- Call tools directly when the user's intent is clear and remain silent until the final answer or a required clarification." + Environment.NewLine +
+                    "- Never repeat, paraphrase, or acknowledge the user's request as filler while tools are running.",
                 ToolCallPreambleMode.BeforeToolBurst =>
                     "# Tool call preambles" + Environment.NewLine +
                     "- If a user request requires a burst of multiple tool calls, say one short bridge sentence before the first call." + Environment.NewLine +
@@ -709,6 +713,18 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 var audioData = delta.GetString();
                 if (!string.IsNullOrEmpty(audioData))
                 {
+                    if (ShouldBufferOutput())
+                    {
+                        var itemId = GetOutputItemKey(root);
+                        if (!_bufferedAudioByItemId.TryGetValue(itemId, out var chunks))
+                        {
+                            chunks = [];
+                            _bufferedAudioByItemId[itemId] = chunks;
+                        }
+                        chunks.Add(audioData);
+                        return;
+                    }
+
                     // Don't log every audio chunk - too verbose
                     OnAudioReceived?.Invoke(audioData);
                 }
@@ -888,6 +904,12 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 var text = transcript.GetString();
                 if (!string.IsNullOrEmpty(text))
                 {
+                    if (ShouldBufferOutput())
+                    {
+                        _bufferedTranscriptsByItemId[GetOutputItemKey(root)] = text;
+                        return;
+                    }
+
                     _logAction(LogLevel.Info, $"Audio transcript: {text}");
                     _currentResponseAudioTranscript = text;
                     if (_currentResponseTrace != null)
@@ -924,6 +946,18 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
             if (root.TryGetProperty("delta", out var deltaElem) &&
                 TryExtractTextDelta(deltaElem, out var deltaText))
             {
+                if (ShouldBufferOutput())
+                {
+                    var itemId = GetOutputItemKey(root);
+                    if (!_bufferedTextByItemId.TryGetValue(itemId, out var textBuffer))
+                    {
+                        textBuffer = new StringBuilder();
+                        _bufferedTextByItemId[itemId] = textBuffer;
+                    }
+                    textBuffer.Append(deltaText);
+                    return;
+                }
+
                 _currentAiMessage.Append(deltaText);
                 _currentResponseOutputText.Append(deltaText);
                 if (_currentResponseTrace != null)
@@ -942,6 +976,7 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 _hasActiveResponse = true;
                 _currentResponseOutputText.Clear();
                 _currentResponseAudioTranscript = null;
+                ClearBufferedOutput();
                 _currentResponseTrace = new OpenAiRealtimeResponseTrace
                 {
                     ResponseId = _currentResponseId,
@@ -986,9 +1021,12 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 OnResponseTraceCompleted?.Invoke(trace);
             }
 
+            FlushBufferedOutput(root);
+
             _currentResponseTrace = null;
             _currentResponseOutputText.Clear();
             _currentResponseAudioTranscript = null;
+            ClearBufferedOutput();
 
             await Task.CompletedTask;
         }
@@ -1109,8 +1147,150 @@ namespace Ai.Tlbx.VoiceAssistant.Provider.OpenAi
                 : null;
         }
 
+        private bool ShouldBufferOutput()
+        {
+            return _settings?.ToolCallPreambleMode == ToolCallPreambleMode.Disabled;
+        }
+
+        private static string GetOutputItemKey(JsonElement root)
+        {
+            var itemId = TryGetString(root, "item_id");
+            if (!string.IsNullOrWhiteSpace(itemId))
+            {
+                return itemId;
+            }
+
+            if (root.TryGetProperty("output_index", out var outputIndex) &&
+                outputIndex.TryGetInt32(out var index))
+            {
+                return $"output:{index}";
+            }
+
+            return "output:unknown";
+        }
+
+        private void FlushBufferedOutput(JsonElement root)
+        {
+            if (!ShouldBufferOutput() ||
+                !root.TryGetProperty("response", out var response) ||
+                !response.TryGetProperty("output", out var output) ||
+                output.ValueKind != JsonValueKind.Array)
+            {
+                FlushAllBufferedOutput();
+                return;
+            }
+
+            var outputItems = output.EnumerateArray().ToArray();
+            var hasPhaseMetadata = outputItems.Any(item => !string.IsNullOrWhiteSpace(TryGetString(item, "phase")));
+
+            for (var index = 0; index < outputItems.Length; index++)
+            {
+                var item = outputItems[index];
+                var phase = TryGetString(item, "phase");
+                if (hasPhaseMetadata && !string.Equals(phase, "final_answer", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var itemId = TryGetString(item, "id") ?? $"output:{index}";
+                FlushBufferedAudio(itemId);
+
+                var transcript = GetOutputItemContent(item, "output_audio", "transcript")
+                    ?? GetBufferedValue(_bufferedTranscriptsByItemId, itemId);
+                var text = GetOutputItemContent(item, "output_text", "text")
+                    ?? GetBufferedText(itemId);
+                var messageText = !string.IsNullOrWhiteSpace(transcript) ? transcript : text;
+                if (!string.IsNullOrWhiteSpace(messageText))
+                {
+                    _currentResponseAudioTranscript = transcript;
+                    _currentResponseOutputText.Clear();
+                    _currentResponseOutputText.Append(text);
+                    OnMessageReceived?.Invoke(ChatMessage.CreateAssistantMessage(messageText));
+                }
+            }
+        }
+
+        private void FlushAllBufferedOutput()
+        {
+            foreach (var chunks in _bufferedAudioByItemId.Values)
+            {
+                foreach (var chunk in chunks)
+                {
+                    OnAudioReceived?.Invoke(chunk);
+                }
+            }
+
+            foreach (var transcript in _bufferedTranscriptsByItemId.Values.Where(value => !string.IsNullOrWhiteSpace(value)))
+            {
+                OnMessageReceived?.Invoke(ChatMessage.CreateAssistantMessage(transcript));
+            }
+
+            if (_bufferedTranscriptsByItemId.Count == 0)
+            {
+                foreach (var text in _bufferedTextByItemId.Values.Select(value => value.ToString()).Where(value => !string.IsNullOrWhiteSpace(value)))
+                {
+                    OnMessageReceived?.Invoke(ChatMessage.CreateAssistantMessage(text));
+                }
+            }
+        }
+
+        private void FlushBufferedAudio(string itemId)
+        {
+            if (!_bufferedAudioByItemId.TryGetValue(itemId, out var chunks))
+            {
+                return;
+            }
+
+            foreach (var chunk in chunks)
+            {
+                OnAudioReceived?.Invoke(chunk);
+            }
+        }
+
+        private static string? GetOutputItemContent(JsonElement item, string contentType, string valueProperty)
+        {
+            if (!item.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            foreach (var part in content.EnumerateArray())
+            {
+                if (string.Equals(TryGetString(part, "type"), contentType, StringComparison.Ordinal) &&
+                    !string.IsNullOrWhiteSpace(TryGetString(part, valueProperty)))
+                {
+                    return TryGetString(part, valueProperty);
+                }
+            }
+
+            return null;
+        }
+
+        private static string? GetBufferedValue(Dictionary<string, string> values, string itemId)
+        {
+            return values.TryGetValue(itemId, out var value) ? value : null;
+        }
+
+        private string? GetBufferedText(string itemId)
+        {
+            return _bufferedTextByItemId.TryGetValue(itemId, out var value) ? value.ToString() : null;
+        }
+
+        private void ClearBufferedOutput()
+        {
+            _bufferedAudioByItemId.Clear();
+            _bufferedTranscriptsByItemId.Clear();
+            _bufferedTextByItemId.Clear();
+        }
+
         private async Task HandleTextDone()
         {
+            if (ShouldBufferOutput())
+            {
+                await Task.CompletedTask;
+                return;
+            }
+
             if (_currentAiMessage.Length > 0)
             {
                 string messageText = _currentAiMessage.ToString();

--- a/Tests/ContractTests/Program.cs
+++ b/Tests/ContractTests/Program.cs
@@ -22,6 +22,7 @@ Assert(new XaiVoiceSettings().Model == XaiVoiceModel.GrokVoiceLatest, "xAI defau
 Assert(XaiVoiceModel.GrokVoiceLatest.ToApiString() == "grok-voice-latest", "xAI latest model id");
 
 await VerifyOpenAiPreambleOutputPolicyAsync();
+VerifyOpenAiPreambleInstructionPolicy();
 
 var directRealtimeClient = File.ReadAllText(FindRepositoryFile(
     "Provider",
@@ -249,10 +250,48 @@ static async Task VerifyOpenAiPreambleOutputPolicyAsync()
     Assert(audio.SequenceEqual(["final-audio"]), "OpenAI disabled preamble preserves final audio");
     Assert(messages.Count == 1 && messages[0].Content == "Die Betonsorte ist C25/30.", "OpenAI disabled preamble preserves final transcript");
 
+    audio.Clear();
+    messages.Clear();
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio.delta","item_id":"mixed_commentary","delta":"discard-this"}""");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio.delta","item_id":"mixed_final","delta":"play-this"}""");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.done","response":{"id":"mixed-response","output":[{"id":"mixed_commentary","type":"message","phase":"commentary","content":[{"type":"output_audio","transcript":"Ich sehe kurz nach."}]},{"id":"mixed_final","type":"message","phase":"final_answer","content":[{"type":"output_audio","transcript":"Gefordert ist C30/37."}]}]}}""");
+    Assert(audio.SequenceEqual(["play-this"]), "OpenAI disabled preamble filters mixed response phases");
+    Assert(messages.Count == 1 && messages[0].Content == "Gefordert ist C30/37.", "OpenAI disabled preamble preserves only mixed final transcript");
+
+    audio.Clear();
+    messages.Clear();
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio.delta","item_id":"legacy_1","delta":"legacy-audio"}""");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio_transcript.done","item_id":"legacy_1","transcript":"Kompatible Ausgabe."}""");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.done","response":{"id":"legacy-response","output":[{"id":"legacy_1","type":"message","content":[{"type":"output_audio","transcript":"Kompatible Ausgabe."}]}]}}""");
+    Assert(audio.SequenceEqual(["legacy-audio"]), "OpenAI disabled preamble preserves providers without phase metadata");
+    Assert(messages.Count == 1 && messages[0].Content == "Kompatible Ausgabe.", "OpenAI disabled preamble preserves transcript without phase metadata");
+
     provider.Settings.ToolCallPreambleMode = ToolCallPreambleMode.BeforeToolBurst;
     await DeliverOpenAiEventAsync(provider,
         """{"type":"response.output_audio.delta","item_id":"commentary_2","delta":"burst-audio"}""");
     Assert(audio.Contains("burst-audio", StringComparer.Ordinal), "OpenAI enabled preamble preserves commentary audio");
+}
+
+static void VerifyOpenAiPreambleInstructionPolicy()
+{
+    var method = typeof(OpenAiVoiceProvider).GetMethod("BuildInstructions", BindingFlags.Static | BindingFlags.NonPublic)
+        ?? throw new MissingMethodException(typeof(OpenAiVoiceProvider).FullName, "BuildInstructions");
+
+    string Build(ToolCallPreambleMode mode) => method.Invoke(null,
+        [new OpenAiVoiceSettings { Instructions = "base-instructions", ToolCallPreambleMode = mode }]) as string
+        ?? throw new InvalidOperationException("OpenAI instruction builder did not return text.");
+
+    Assert(Build(ToolCallPreambleMode.ProviderDefault) == "base-instructions", "OpenAI provider default preserves instructions");
+    Assert(Build(ToolCallPreambleMode.Disabled).Contains("remain silent until the final answer", StringComparison.Ordinal), "OpenAI disabled mode instruction");
+    Assert(Build(ToolCallPreambleMode.BeforeToolBurst).Contains("burst of multiple tool calls", StringComparison.Ordinal), "OpenAI tool burst instruction");
+    Assert(Build(ToolCallPreambleMode.ForLongRunningTools).Contains("noticeable time", StringComparison.Ordinal), "OpenAI long-running tool instruction");
+    Assert(Build(ToolCallPreambleMode.BeforeEveryToolCall).Contains("Before any tool call", StringComparison.Ordinal), "OpenAI every-tool instruction");
 }
 
 static async Task DeliverOpenAiEventAsync(OpenAiVoiceProvider provider, string json)

--- a/Tests/ContractTests/Program.cs
+++ b/Tests/ContractTests/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Reflection;
 using Ai.Tlbx.VoiceAssistant.Managers;
 using Ai.Tlbx.VoiceAssistant.Models;
 using Ai.Tlbx.VoiceAssistant.Provider.Google;
@@ -19,6 +20,8 @@ Assert(OpenAiRealtimeModel.GptRealtime21.ToApiString() == "gpt-realtime-2.1", "O
 Assert(OpenAiRealtimeModel.GptRealtime21Mini.ToApiString() == "gpt-realtime-2.1-mini", "OpenAI 2.1 mini model id");
 Assert(new XaiVoiceSettings().Model == XaiVoiceModel.GrokVoiceLatest, "xAI default model");
 Assert(XaiVoiceModel.GrokVoiceLatest.ToApiString() == "grok-voice-latest", "xAI latest model id");
+
+await VerifyOpenAiPreambleOutputPolicyAsync();
 
 var directRealtimeClient = File.ReadAllText(FindRepositoryFile(
     "Provider",
@@ -208,6 +211,57 @@ static void Assert(bool condition, string contract)
     {
         throw new InvalidOperationException($"Contract failed: {contract}");
     }
+}
+
+static async Task VerifyOpenAiPreambleOutputPolicyAsync()
+{
+    await using var provider = new OpenAiVoiceProvider("contract-test-key")
+    {
+        Settings = new OpenAiVoiceSettings
+        {
+            ToolCallPreambleMode = ToolCallPreambleMode.Disabled
+        }
+    };
+
+    var audio = new List<string>();
+    var messages = new List<ChatMessage>();
+    provider.OnAudioReceived = audio.Add;
+    provider.OnMessageReceived = messages.Add;
+
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio.delta","item_id":"commentary_1","delta":"ignored-audio"}""");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio_transcript.done","item_id":"commentary_1","transcript":"Einen Moment, ich schaue nach."}""");
+    Assert(audio.Count == 0, "OpenAI disabled preamble suppresses commentary audio");
+    Assert(messages.Count == 0, "OpenAI disabled preamble suppresses commentary transcript");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.done","response":{"id":"commentary-response","output":[{"id":"commentary_1","type":"message","phase":"commentary","content":[{"type":"output_audio","transcript":"Einen Moment, ich schaue nach."}]}]}}""");
+    Assert(audio.Count == 0, "OpenAI disabled preamble discards completed commentary audio");
+    Assert(messages.Count == 0, "OpenAI disabled preamble discards completed commentary transcript");
+
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio.delta","item_id":"final_1","delta":"final-audio"}""");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio_transcript.done","item_id":"final_1","transcript":"Die Betonsorte ist C25/30."}""");
+    Assert(audio.Count == 0, "OpenAI disabled preamble buffers final audio until its phase is known");
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.done","response":{"id":"final-response","output":[{"id":"final_1","type":"message","phase":"final_answer","content":[{"type":"output_audio","transcript":"Die Betonsorte ist C25/30."}]}]}}""");
+    Assert(audio.SequenceEqual(["final-audio"]), "OpenAI disabled preamble preserves final audio");
+    Assert(messages.Count == 1 && messages[0].Content == "Die Betonsorte ist C25/30.", "OpenAI disabled preamble preserves final transcript");
+
+    provider.Settings.ToolCallPreambleMode = ToolCallPreambleMode.BeforeToolBurst;
+    await DeliverOpenAiEventAsync(provider,
+        """{"type":"response.output_audio.delta","item_id":"commentary_2","delta":"burst-audio"}""");
+    Assert(audio.Contains("burst-audio", StringComparer.Ordinal), "OpenAI enabled preamble preserves commentary audio");
+}
+
+static async Task DeliverOpenAiEventAsync(OpenAiVoiceProvider provider, string json)
+{
+    var method = typeof(OpenAiVoiceProvider).GetMethod("ProcessReceivedMessage", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new MissingMethodException(typeof(OpenAiVoiceProvider).FullName, "ProcessReceivedMessage");
+    var task = method.Invoke(provider, [json]) as Task
+        ?? throw new InvalidOperationException("OpenAI event processor did not return a task.");
+    await task;
 }
 
 static string FindRepositoryFile(params string[] relativeSegments)

--- a/publish-nuget-current-version.ps1
+++ b/publish-nuget-current-version.ps1
@@ -85,7 +85,7 @@ foreach ($project in $projects)
     dotnet restore $projectPath
     
     # Build and pack the project
-    dotnet build $projectPath -c $Configuration
+    dotnet build $projectPath -c $Configuration -m:14
     
     if ($LASTEXITCODE -ne 0) 
     {

--- a/verify-release.ps1
+++ b/verify-release.ps1
@@ -17,7 +17,7 @@ function Assert-LastCommandSucceeded([string]$Step)
 Push-Location $PSScriptRoot
 try
 {
-    dotnet build TLBX.Ai.VoiceAssistant.slnx -c $Configuration --nologo
+    dotnet build TLBX.Ai.VoiceAssistant.slnx -c $Configuration --nologo -m:14
     Assert-LastCommandSucceeded "Solution build"
 
     dotnet run --project Tests\ContractTests\ContractTests.csproj -c $Configuration --no-build
@@ -46,7 +46,7 @@ try
             & $developerShell -Arch amd64 -HostArch amd64 -SkipAutomaticLocation
         }
 
-        dotnet publish Tests\AotTest\AotTest.csproj -c $Configuration -r $RuntimeIdentifier --self-contained true --nologo
+        dotnet publish Tests\AotTest\AotTest.csproj -c $Configuration -r $RuntimeIdentifier --self-contained true --nologo -m:14
         Assert-LastCommandSucceeded "Native AOT publish"
     }
 


### PR DESCRIPTION
## Ursache

`ToolCallPreambleMode` beeinflusste OpenAI bislang nur über Session-Instructions. Audio-Deltas wurden unabhängig von der Realtime-Ausgabephase sofort abgespielt. Dadurch konnte das Modell trotz `Disabled` gesprochene Commentary-/Zeitschindephrasen ausgeben.

## Änderung

- Paketversion auf 10.2.1 erhöht
- OpenAI-Preamble-Instructions für alle Modi präzisiert
- bei `Disabled` Audio, Transcript und Text bis `response.done` gepuffert
- `commentary` verworfen und ausschließlich `final_answer` ausgegeben
- kompatibler Fallback für Responses ohne Phasenmetadaten
- identische Promptregel im direkten ASP.NET-Core-Realtime-Pfad
- Release-Builds auf maximal 14 MSBuild-Worker begrenzt

## Verifikation

- Provider-Contracttests erfolgreich
- alle fünf `ToolCallPreambleMode`-Varianten geprüft
- gemischte Commentary-/Final-Responses geprüft
- phasenloser Kompatibilitätsfallback geprüft
- Solution-Release-Build und Console-Demo-Smoke-Test erfolgreich
- Native-AOT-Gate lokal nicht ausgeführt: Visual-C++-x64-Toolchain fehlt